### PR TITLE
Feature/transform hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ Inside the Term Template block, you can add [certain blocks](#block-variations) 
 | Argument | Possible Values | Description |
 | --- | --- | --- |
 | `key` | Any meta key | The key of the term meta to display. |
-| `transform` | `attachmentURL`, `attachmentImageAlt` | A transformation to apply to the meta value. Transformations are detailed below. |
+| `transform` | `attachment_id_to_url`, `attachment_id_to_image_alt` | A transformation to apply to the meta value. Transformations are detailed below. |
 
 ### Transformations
 
 Term meta values often contain just an ID that needs to be transformed into a useable value. The following transformations are available:
 
-- **attachmentURL**: Transforms an attachment ID into the URL of the attachment.
-- **attachmentImageAlt**: Transforms an attachment ID into the alt text of the attachment.
+- **attachment_id_to_url**: Transforms an attachment ID into the URL of the attachment.
+- **attachment_id_to_image_alt**: Transforms an attachment ID into the alt text of the attachment.

--- a/README.md
+++ b/README.md
@@ -42,11 +42,15 @@ Inside the Term Template block, you can add [certain blocks](#block-variations) 
 | Argument | Possible Values | Description |
 | --- | --- | --- |
 | `key` | Any meta key | The key of the term meta to display. |
-| `transform` | `attachment_id_to_url`, `attachment_id_to_image_alt` | A transformation to apply to the meta value. Transformations are detailed below. |
+| `transform` | `attachment_id_to_url`, `attachment_id_to_image_alt`, custom transform key | A transformation to apply to the meta value. Built-in transformations are detailed below. |
 
 ### Transformations
 
-Term meta values often contain just an ID that needs to be transformed into a useable value. The following transformations are available:
+Term meta values often contain values that must be transformed into something else to be useable, such as an attachment ID into a URL.
+
+The following transformations are available in the plugin:
 
 - **attachment_id_to_url**: Transforms an attachment ID into the URL of the attachment.
 - **attachment_id_to_image_alt**: Transforms an attachment ID into the alt text of the attachment.
+
+To create a custom transform, you can use the `term_query_term_meta_transform_{$transform_key}` filter in PHP for the front end and the `termQuery.termMetaTransform.{$transformKey}` filter in JavaScript for the editor. See [includes/transforms.php](/includes/transforms.php) and [src/editor/transforms.js](/src/editor/transforms.js) to reference how the built-in transforms are implemented.

--- a/includes/block-bindings.php
+++ b/includes/block-bindings.php
@@ -106,15 +106,24 @@ function get_term_meta_value( array $source_args, WP_Block $block_instance, stri
 
 	$meta_value = get_term_meta( $term_id, $source_args['key'], true );
 
+	/**
+	 * Filter all term meta values.
+	 *
+	 * @param mixed $meta_value The term meta value.
+	 * @param array $source_args The source args.
+	 * @return mixed The filtered term meta value. Return null to prevent the block from rendering.
+	 */
+	$meta_value = apply_filters( 'term_query_term_meta', $meta_value, $source_args );
+
 	if ( ! empty( $source_args['transform'] ) ) {
-		switch ( $source_args['transform'] ) {
-			case 'attachmentURL':
-				$meta_value = wp_get_attachment_image_src( $meta_value, 'large' );
-				break;
-			case 'attachmentImageAlt':
-				$meta_value = get_post_meta( $meta_value, '_wp_attachment_image_alt', true );
-				break;
-		}
+		/**
+		 * Filter term meta transform values by key.
+		 *
+		 * @param mixed $meta_value The term meta value.
+		 * @param array $source_args The source args.
+		 * @return mixed The transformed term meta value. Return null to prevent the block from rendering.
+		 */
+		$meta_value = apply_filters( "term_query_term_meta_transform_{$source_args['transform']}", $meta_value, $source_args );
 	}
 
 	return $meta_value;

--- a/includes/block-bindings.php
+++ b/includes/block-bindings.php
@@ -80,7 +80,7 @@ function get_term_value( array $source_args, WP_Block $block_instance, string $a
 	// Additional keys that require special handling.
 	return match ( $source_args['key'] ) {
 		'link' => get_term_link( $term ),
-		default => $term_id,
+		default => null,
 	};
 }
 

--- a/includes/transforms.php
+++ b/includes/transforms.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Include: transforms.php
+ *
+ * Registers term query term meta transform filters.
+ *
+ * @author    Cory Hughart <cory@coryhughart.com>
+ * @copyright 2024 Cory Hughart
+ * @license   https://www.gnu.org/licenses/gpl-3.0.html GPL-3.0-or-later
+ * @link      https://github.com/cr0ybot/term-query
+ * @package   term-query
+ */
+
+namespace cr0ybot\Term_Query\Transforms;
+
+add_filter( 'term_query_term_meta_transform_attachment_id_to_url', __NAMESPACE__ . '\\attachment_id_to_url', 10, 2 );
+add_filter( 'term_query_term_meta_transform_attachment_id_to_image_alt', __NAMESPACE__ . '\\attachment_id_to_image_alt', 10, 2 );
+
+/**
+ * Transform to attachment URL.
+ *
+ * @param mixed $meta_value The meta value, an attachment ID.
+ * @param array $args The binding args.
+ * @return string|null The attachment URL or null.
+ */
+function attachment_id_to_url( mixed $meta_value, array $args ) {
+	if ( ! is_numeric( $meta_value ) ) {
+		return null;
+	}
+
+	$url = wp_get_attachment_image_url( $meta_value, $args['size'] ?? 'full' );
+	if ( ! $url ) {
+		return null;
+	}
+
+	return $url;
+}
+
+/**
+ * Transform to attachment image alt text.
+ *
+ * @param mixed $meta_value The meta value, an attachment ID.
+ * @param array $args The binding args.
+ * @return string|null The attachment alt text or null.
+ */
+function attachment_id_to_image_alt( mixed $meta_value, array $args ) {
+	if ( ! is_numeric( $meta_value ) ) {
+		return null;
+	}
+
+	$alt = get_post_meta( $meta_value, '_wp_attachment_id_to_image_alt', true );
+	if ( ! $alt ) {
+		return null;
+	}
+
+	return $alt;
+}

--- a/readme.txt
+++ b/readme.txt
@@ -75,14 +75,14 @@ registerBlockVariation( 'core/image', {
 					source: 'term-query/term-meta',
 					args: {
 						'key': 'thumbnail_id',
-						'transform': 'attachmentURL',
+						'transform': 'attachment_id_to_url',
 					},
 				},
 				alt: {
 					source: 'term-query/term-meta',
 					args: {
 						'key': 'thumbnail_id',
-						'transform': 'attachmentImageAlt',
+						'transform': 'attachment_id_to_image_alt',
 					},
 				},
 			},

--- a/readme.txt
+++ b/readme.txt
@@ -92,6 +92,46 @@ registerBlockVariation( 'core/image', {
 } );
 ```
 
+= What if I need to transform a custom term meta value in a different way? =
+
+If you need to perform transforms on term meta values other than the built-in ones for attachments, you can use your own transform key and add filters to handle the transform. For example, if you have a term meta field `color` that stores a hex color value and you want to prepend a "#", you'll need to set the block attributes to use your custom term meta key and custom transform key:
+
+```js
+{
+	[...]
+	attributes: {
+		metadata: {
+			bindings: {
+				content: {
+					source: 'term-query/term-meta',
+					args: {
+						'key': 'my_color',
+						'transform: 'prepend_octothorpe',
+					},
+				},
+			},
+		},
+	},
+	[...]
+}
+```
+
+And then you'll need to add a filter in PHP (front end):
+
+```php
+add_filter( 'term_query_term_meta_transform_prepend_octothorpe', function( $value ) {
+	return '#' . $value;
+} );
+```
+
+...and JS (block editor):
+
+```js
+addFilter( 'termQuery.termMetaTransform.prepend_octothorpe', 'me/my-plugin/prepend-octothorpe', function( value ) {
+	return `#${value}`;
+} );
+```
+
 = What does the ‡ symbol mean? =
 
 The "double dagger" (‡) is a typographical mark generally used to indicate a footnote after both an asterisk (*) and a regular dagger (†) have been used.

--- a/src/blocks/term-template/edit.js
+++ b/src/blocks/term-template/edit.js
@@ -31,14 +31,14 @@ const TEMPLATE = [
 					source: 'term-query/term-meta',
 					args: {
 						'key': 'thumbnail_id',
-						'transform': 'attachmentURL',
+						'transform': 'attachment_id_to_url',
 					},
 				},
 				alt: {
 					source: 'term-query/term-meta',
 					args: {
 						'key': 'thumbnail_id',
-						'transform': 'attachmentImageAlt',
+						'transform': 'attachment_id_to_image_alt',
 					},
 				},
 			},

--- a/src/editor/block-bindings.js
+++ b/src/editor/block-bindings.js
@@ -7,6 +7,7 @@ import { __ } from '@wordpress/i18n';
 import { store as coreDataStore } from '@wordpress/core-data';
 
 import { applyFilters } from './hooks';
+import './transforms';
 
 const TERM_KEYS = [
 	'count',

--- a/src/editor/hooks.js
+++ b/src/editor/hooks.js
@@ -1,0 +1,25 @@
+/**
+ * Editor: hooks.
+ */
+
+import { createHooks } from '@wordpress/hooks';
+
+if ( ! window.termQueryHooks ) {
+	const termQueryHooks = createHooks();
+	window.termQueryHooks = termQueryHooks;
+}
+
+export const {
+	filters,
+	addFilter,
+	applyFilters,
+	removeFilter,
+	removeAllFilters,
+	actions,
+	addAction,
+	doAction,
+	removeAction,
+	removeAllActions,
+} = window.termQueryHooks;
+
+export default window.termQueryHooks;

--- a/src/editor/transforms.js
+++ b/src/editor/transforms.js
@@ -1,0 +1,40 @@
+/**
+ * Editor: transforms.
+ */
+
+import { addFilter } from './hooks';
+
+/**
+ * Transform to attachment URL.
+ */
+addFilter( 'termQuery.termMetaTransform.attachment_id_to_url', 'term-query/term-meta-transform/attachment_id_to_url', ( value, args, select ) => {
+	// If value is not numeric, return early.
+	if ( isNaN( value ) ) {
+		return null;
+	}
+
+	const attachment = select( 'core' ).getMedia( value );
+	if ( ! attachment ) {
+		return null;
+	}
+
+	const size = args?.size ?? 'full';
+	return attachment.media_details.sizes[ size ]?.source_url ?? attachment.source_url;
+} );
+
+/**
+ * Transform to attachment image alt.
+ */
+addFilter( 'termQuery.termMetaTransform.attachment_id_to_image_alt', 'term-query/term-meta-transform/attachment_id_to_image_alt', ( value, args, select ) => {
+	// If value is not numeric, return early.
+	if ( isNaN( value ) ) {
+		return null;
+	}
+
+	const attachment = select( 'core' ).getMedia( value );
+	if ( ! attachment ) {
+		return null;
+	}
+
+	return attachment.alt_text;
+} );


### PR DESCRIPTION
Closes #2

Removes hardcoded transforms in favor of a hook system.

Built-in transforms are moved to the hook system internally, but also have been renamed to be more descriptive.