### PR TITLE
Feature/nested term query

### DIFF
--- a/src/blocks/term-query/block.json
+++ b/src/blocks/term-query/block.json
@@ -47,6 +47,11 @@
 		"term-query/stickyTerms": "stickyTerms",
 		"term-query/displayLayout": "displayLayout"
 	},
+	"usesContext": [
+		"term-query/queryId",
+		"term-query/query",
+		"term-query/taxonomy"
+	],
 	"supports": {
 		"align": [
 			"wide",

--- a/src/blocks/term-query/block.json
+++ b/src/blocks/term-query/block.json
@@ -43,7 +43,6 @@
 	"providesContext": {
 		"term-query/queryId": "queryId",
 		"term-query/query": "query",
-		"term-query/taxonomy": "taxonomy",
 		"term-query/stickyTerms": "stickyTerms",
 		"term-query/displayLayout": "displayLayout"
 	},

--- a/src/blocks/term-query/edit/index.js
+++ b/src/blocks/term-query/edit/index.js
@@ -8,14 +8,20 @@ import QueryContent from './query-content';
 import QueryPlaceholder from './query-placeholder';
 
 const QueryEdit = ( props ) => {
-	const { attributes, clientId } = props;
+	const { attributes, clientId, context } = props;
 	const { taxonomy } = attributes;
+	const {
+		'term-query/queryId': queryIdContext,
+		'term-query/taxonomy': taxonomyContext,
+	} = context;
+
 	const hasInnerBlocks = useSelect(
 		( select ) =>
 			!! select( blockEditorStore ).getBlocks( clientId ).length,
 		[ clientId ]
 	);
-	const Component = hasInnerBlocks || taxonomy ? QueryContent : QueryPlaceholder;
+
+	const Component = hasInnerBlocks || taxonomy || (queryIdContext && taxonomyContext) ? QueryContent : QueryPlaceholder;
 	return (
 		<Component
 			{ ...props }

--- a/src/blocks/term-query/edit/inspector-controls/index.js
+++ b/src/blocks/term-query/edit/inspector-controls/index.js
@@ -22,7 +22,12 @@ import {
 export default function QueryInspectorControls( props ) {
 	const { attributes, setQuery, setDisplayLayout, setAttributes } =
 		props;
-	const { query, taxonomy, stickyTerms, displayLayout } = attributes;
+	const {
+		query,
+		taxonomy,
+		stickyTerms,
+		displayLayout,
+	} = attributes;
 	const {
 		order,
 		orderBy,
@@ -84,6 +89,7 @@ export default function QueryInspectorControls( props ) {
 								<TaxonomyControl
 									onChange={ updateTaxonomy }
 									taxonomy={ taxonomy }
+									inherited={ inherit }
 								/>
 							) }
 							{ showStickyTermsControl && (

--- a/src/blocks/term-query/edit/inspector-controls/sticky-terms-control.js
+++ b/src/blocks/term-query/edit/inspector-controls/sticky-terms-control.js
@@ -3,6 +3,7 @@ import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { useState, useEffect } from '@wordpress/element';
 import { useDebounce } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
 
 const EMPTY_ARRAY = [];
 const BASE_QUERY = {
@@ -15,7 +16,7 @@ const BASE_QUERY = {
  * Renders a `FormTokenField` for the given taxonomy.
  *
  * @param {Object}   props          The props for the component.
- * @param {Object}   props.taxonomy The taxonomy object.
+ * @param {string}   props.taxonomy The taxonomy slug.
  * @param {number[]} props.stickyTerms  An array with the block's term ids for the given taxonomy.
  * @param {Function} props.onChange Callback `onChange` function.
  * @return {JSX.Element} The rendered component.
@@ -34,7 +35,7 @@ export default function StickyTermsControl( { taxonomy, stickyTerms, onChange } 
 				select( coreStore );
 			const selectorArgs = [
 				'taxonomy',
-				taxonomy.slug,
+				taxonomy,
 				{
 					...BASE_QUERY,
 					search,
@@ -110,7 +111,7 @@ export default function StickyTermsControl( { taxonomy, stickyTerms, onChange } 
 			<FormTokenField
 				__nextHasNoMarginBottom
 				__next40pxDefaultSize
-				label={ taxonomy.name }
+				label={ __( 'Sticky Terms', 'term-query' ) }
 				value={ value }
 				onInputChange={ debouncedSearch }
 				suggestions={ suggestions }

--- a/src/blocks/term-query/edit/inspector-controls/taxonomy-control.js
+++ b/src/blocks/term-query/edit/inspector-controls/taxonomy-control.js
@@ -1,27 +1,42 @@
-import { ComboboxControl } from '@wordpress/components';
+import {
+	ComboboxControl,
+	TextControl,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 import { useTaxonomies } from '../../utils';
 
-export default function TaxonomyControl( { onChange, taxonomy } ) {
+export default function TaxonomyControl( { onChange, taxonomy, inherited } ) {
 	const taxonomies = useTaxonomies();
 	if ( ! taxonomies || taxonomies.length === 0 ) {
 		return null;
 	}
 
-	return (
-		<>
-			<ComboboxControl
+	if ( inherited ) {
+		const label = taxonomies.find( ( { slug } ) => slug === taxonomy )?.name ?? taxonomy;
+
+		return (
+			<TextControl
 				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 				label={ __( 'Taxonomy', 'term-query' ) }
-				value={ taxonomy }
-				onChange={ onChange }
-				options={ taxonomies.map( ( { slug, name } ) => ( {
-					value: slug,
-					label: name,
-				} ) ) }
+				value={ label }
+				disabled
 			/>
-		</>
+		);
+	}
+
+	return (
+		<ComboboxControl
+			__nextHasNoMarginBottom
+			__next40pxDefaultSize
+			label={ __( 'Taxonomy', 'term-query' ) }
+			value={ taxonomy }
+			onChange={ onChange }
+			options={ taxonomies.map( ( { slug, name } ) => ( {
+				value: slug,
+				label: name,
+			} ) ) }
+		/>
 	);
 }

--- a/src/blocks/term-query/edit/query-content.js
+++ b/src/blocks/term-query/edit/query-content.js
@@ -74,9 +74,15 @@ export default function QueryContent( props ) {
 	// would cause to override previous wanted changes.
 	useEffect( () => {
 		const newQuery = {};
+		let newInherit = inherit;
+		// Update inherit if context is available.
+		if ( taxonomyContext && ! inherit ) {
+			newQuery.inherit = true;
+			newInherit = true;
+		}
 		// When we inherit from global query always need to set the `perPage`
 		// based on the reading settings.
-		if ( inherit && query.perPage !== postsPerPage ) {
+		if ( newInherit && query.perPage !== postsPerPage ) {
 			newQuery.perPage = postsPerPage;
 		} else if ( ! query.perPage && postsPerPage ) {
 			newQuery.perPage = postsPerPage;
@@ -85,7 +91,7 @@ export default function QueryContent( props ) {
 			__unstableMarkNextChangeAsNotPersistent();
 			updateQuery( newQuery );
 		}
-	}, [ query.perPage, postsPerPage, inherit ] );
+	}, [ query.perPage, postsPerPage, inherit, taxonomyContext ] );
 	// We need this for multi-query block pagination.
 	// Query parameters for each block are scoped to their ID.
 	useEffect( () => {

--- a/src/blocks/term-query/edit/query-content.js
+++ b/src/blocks/term-query/edit/query-content.js
@@ -60,8 +60,15 @@ export default function QueryContent( props ) {
 	}, [] );
 
 	// Maybe inherit taxonomy from global query if not set in the block.
-	const taxonomyInherited = inherit && ! taxonomyAttribute && queryIdContext && taxonomyContext;
+	const taxonomyInherited = inherit && ! taxonomyAttribute && (!!queryIdContext && !!taxonomyContext);
 	const taxonomy = taxonomyInherited ? taxonomyContext : taxonomyAttribute;
+
+	/**
+	 * The term-query/taxonomy context is not declared in the block.json file's
+	 * `providersContext` property so that we can control the value without
+	 * being beholden to the block's attribute value.
+	 */
+	const taxonomyContextObject = { 'term-query/taxonomy': taxonomy };
 
 	// There are some effects running where some initialization logic is
 	// happening and setting some values to some attributes (ex. queryId).
@@ -123,7 +130,12 @@ export default function QueryContent( props ) {
 			<QueryInspectorControls
 				{ ...props }
 				setQuery={ updateQuery }
-				taxonomy={ taxonomy }
+				attributes={
+					{
+						...attributes,
+						taxonomy, // Maybe override taxonomy with inherited value.
+					}
+				}
 			/>
 			<BlockControls>
 				<QueryToolbar
@@ -151,16 +163,11 @@ export default function QueryContent( props ) {
 					help={ htmlElementMessages[ TagName ] }
 				/>
 			</InspectorControls>
-			{ !!taxonomyInherited ? (
-				<BlockContextProvider
-					key="term-query/taxonomy"
-					value={ taxonomyInherited }
-				>
-					<TagName { ...innerBlocksProps } />
-				</BlockContextProvider>
-			) : (
+			<BlockContextProvider
+				value={ taxonomyContextObject }
+			>
 				<TagName { ...innerBlocksProps } />
-			) }
+			</BlockContextProvider>
 		</>
 	);
 }

--- a/src/blocks/term-template/block.json
+++ b/src/blocks/term-template/block.json
@@ -13,6 +13,7 @@
 		"term-query/queryId",
 		"term-query/query",
 		"term-query/taxonomy",
+		"term-query/termId",
 		"term-query/stickyTerms",
 		"term-query/displayLayout",
 		"templateSlug",

--- a/src/blocks/term-template/edit.js
+++ b/src/blocks/term-template/edit.js
@@ -164,7 +164,7 @@ export default function TermTemplateEdit( {
 } ) {
 	const { type: layoutType, columnCount = 3 } = layout || {};
 	const [ activeBlockContextId, setActiveBlockContextId ] = useState();
-	const { terms, blocks } = useSelect(
+	const { terms, termsLoading, blocks } = useSelect(
 		( select ) => {
 			const { getEntityRecords } = select( coreStore );
 			const { getBlocks } = select( blockEditorStore );
@@ -228,6 +228,19 @@ export default function TermTemplateEdit( {
 				}
 			}
 
+			const termsLoading = select('core/data').isResolving(
+				'core',
+				'getEntityRecords',
+				[
+					'taxonomy',
+					taxonomy,
+					{
+						...query,
+						...restQueryArgs,
+					},
+				]
+			);
+
 			return {
 				terms: [
 					...(fetchedStickyTerms ?? []),
@@ -236,6 +249,7 @@ export default function TermTemplateEdit( {
 						...restQueryArgs,
 					} ) ?? []),
 				],
+				termsLoading,
 				blocks: getBlocks( clientId ),
 			};
 		},
@@ -273,7 +287,7 @@ export default function TermTemplateEdit( {
 		} ),
 	} );
 
-	if ( ! terms ) {
+	if ( termsLoading ) {
 		return (
 			<p { ...blockProps }>
 				<Spinner />

--- a/src/blocks/term-template/edit.js
+++ b/src/blocks/term-template/edit.js
@@ -8,7 +8,7 @@ import clsx from 'clsx';
  */
 import { memo, useMemo, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-import { __, _x } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import {
 	BlockControls,
 	BlockContextProvider,
@@ -289,9 +289,16 @@ export default function TermTemplateEdit( {
 
 	if ( termsLoading ) {
 		return (
-			<p { ...blockProps }>
-				<Spinner />
-			</p>
+			<div { ...blockProps }>
+				<p className="wp-block-term-query__loading">
+					<Spinner />
+					{ sprintf(
+						/* translators: %s: taxonomy slug */
+						__( 'Loading %s terms…', 'term-query' ),
+						taxonomy
+					) }
+				</p>
+			</div>
 		);
 	}
 


### PR DESCRIPTION
Closes #15

Allows Term Query Loop blocks to be nested, automatically setting `inherit` to true when inserted and getting `taxonomy` from the parent Term Query Loop context.

The nested loop will use the current `term-query/termId` context to set the parent term ID for the loop.

Note that `term-query/taxonomy` was removed from `providesContext` because otherwise the value is served directly from the block's attributes with no way of overriding.