### PR TITLE
Feature/parent inspector control

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.4.0",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
+				"@tanstack/react-query": "^5.62.8",
 				"clsx": "^2.1.1",
 				"lucide-static": "^0.468.0"
 			},
@@ -3580,6 +3581,30 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/@tanstack/query-core": {
+			"version": "5.62.8",
+			"resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.62.8.tgz",
+			"integrity": "sha512-4fV31vDsUyvNGrKIOUNPrZztoyL187bThnoQOvAXEVlZbSiuPONpfx53634MKKdvsDir5NyOGm80ShFaoHS/mw==",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			}
+		},
+		"node_modules/@tanstack/react-query": {
+			"version": "5.62.8",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.62.8.tgz",
+			"integrity": "sha512-8TUstKxF/fysHonZsWg/hnlDVgasTdHx6Q+f1/s/oPKJBJbKUWPZEHwLTMOZgrZuroLMiqYKJ9w69Abm8mWP0Q==",
+			"dependencies": {
+				"@tanstack/query-core": "5.62.8"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			},
+			"peerDependencies": {
+				"react": "^18 || ^19"
 			}
 		},
 		"node_modules/@tootallnate/once": {
@@ -12549,8 +12574,7 @@
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
 		"node_modules/js-yaml": {
 			"version": "3.14.1",
@@ -13258,7 +13282,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"dev": true,
 			"dependencies": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			},
@@ -16148,7 +16171,6 @@
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
 			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-			"dev": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			},

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"replace-in-file": "^8.2.0"
 	},
 	"dependencies": {
+		"@tanstack/react-query": "^5.62.8",
 		"clsx": "^2.1.1",
 		"lucide-static": "^0.468.0"
 	}

--- a/src/blocks/term-query/block.json
+++ b/src/blocks/term-query/block.json
@@ -49,7 +49,8 @@
 	"usesContext": [
 		"term-query/queryId",
 		"term-query/query",
-		"term-query/taxonomy"
+		"term-query/taxonomy",
+		"term-query/termId"
 	],
 	"supports": {
 		"align": [

--- a/src/blocks/term-query/edit/index.js
+++ b/src/blocks/term-query/edit/index.js
@@ -4,10 +4,11 @@
 import { useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
+import withTermQueryProvider from '../../../queries/withTermQueryProvider';
 import QueryContent from './query-content';
 import QueryPlaceholder from './query-placeholder';
 
-const QueryEdit = ( props ) => {
+const TermQueryEdit = ( props ) => {
 	const { attributes, clientId, context } = props;
 	const { taxonomy } = attributes;
 	const {
@@ -29,4 +30,4 @@ const QueryEdit = ( props ) => {
 	);
 };
 
-export default QueryEdit;
+export default withTermQueryProvider( TermQueryEdit );

--- a/src/blocks/term-query/edit/inspector-controls/index.js
+++ b/src/blocks/term-query/edit/inspector-controls/index.js
@@ -11,6 +11,7 @@ import {
 } from '@wordpress/block-editor';
 
 import OrderControl from './order-control';
+import ParentControl from './parent-control';
 import TaxonomyControl from './taxonomy-control';
 import StickyTermsControl from './sticky-terms-control';
 import {
@@ -31,6 +32,7 @@ export default function QueryInspectorControls( props ) {
 	const {
 		order,
 		orderBy,
+		parent,
 		hideEmpty,
 		inherit,
 	} = query;
@@ -41,10 +43,11 @@ export default function QueryInspectorControls( props ) {
 		setAttributes( { taxonomy: value, stickyTerms: [] } );
 	};
 
+	const showInheritControl = isControlAllowed( allowedControls, 'inherit' );
 	const showTaxControl =
 		!! taxonomies?.length &&
 		isControlAllowed( allowedControls, 'taxonomy' );
-	const showInheritControl = isControlAllowed( allowedControls, 'inherit' );
+	const showParentControl = showTaxControl && isControlAllowed( allowedControls, 'parent' );
 	const showColumnsControl = false;
 	const showOrderControl =
 		! inherit && isControlAllowed( allowedControls, 'order' );
@@ -88,6 +91,16 @@ export default function QueryInspectorControls( props ) {
 							{ showTaxControl && (
 								<TaxonomyControl
 									onChange={ updateTaxonomy }
+									taxonomy={ taxonomy }
+									inherited={ inherit }
+								/>
+							) }
+							{ showParentControl && (
+								<ParentControl
+									onChange={ ( value ) =>
+										setQuery( { parent: value } )
+									}
+									parent={ parent }
 									taxonomy={ taxonomy }
 									inherited={ inherit }
 								/>

--- a/src/blocks/term-query/edit/inspector-controls/parent-control.js
+++ b/src/blocks/term-query/edit/inspector-controls/parent-control.js
@@ -11,7 +11,6 @@ export const ParentControl = ( { parent = 0, taxonomy, onChange, inherited } ) =
 	const [ searchInput, setSearchInput, debouncedSearch ] = useDebouncedInput( '' );
 	const {
 		data: termsData,
-
 	} = useTerms( {
 		taxonomy,
 		parent,
@@ -21,8 +20,6 @@ export const ParentControl = ( { parent = 0, taxonomy, onChange, inherited } ) =
 		data: currentTerm = null,
 	} = useTerm( taxonomy, parent );
 	const terms = termsData?.pages?.flat() ?? [];
-
-	console.log( { parent, currentTerm, terms } );
 
 	const handleChange = ( value ) => {
 		onChange( value ? parseInt( value ) : 0 );

--- a/src/blocks/term-query/edit/inspector-controls/parent-control.js
+++ b/src/blocks/term-query/edit/inspector-controls/parent-control.js
@@ -1,0 +1,62 @@
+import {
+	ComboboxControl,
+	TextControl,
+} from '@wordpress/components';
+import { useDebouncedInput } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+
+import { useTerm, useTerms } from '../../../../queries/terms';
+
+export const ParentControl = ( { parent = 0, taxonomy, onChange, inherited } ) => {
+	const [ searchInput, setSearchInput, debouncedSearch ] = useDebouncedInput( '' );
+	const {
+		data: termsData,
+
+	} = useTerms( {
+		taxonomy,
+		parent,
+		...( debouncedSearch ? { search: debouncedSearch } : {} ),
+	} );
+	const {
+		data: currentTerm = null,
+	} = useTerm( taxonomy, parent );
+	const terms = termsData?.pages?.flat() ?? [];
+
+	console.log( { parent, currentTerm, terms } );
+
+	const handleChange = ( value ) => {
+		onChange( value ? parseInt( value ) : 0 );
+	};
+
+	if ( inherited ) {
+		const label = currentTerm?.name ?? parent;
+
+		return (
+			<TextControl
+				__nextHasNoMarginBottom
+				__next40pxDefaultSize
+				label={ __( 'Parent Term', 'term-query' ) }
+				value={ label }
+				disabled
+			/>
+		);
+	}
+
+	return (
+		<ComboboxControl
+			__nextHasNoMarginBottom
+			__next40pxDefaultSize
+			label={ __( 'Parent Term', 'term-query' ) }
+			placeholder={ __( 'Search for a term', 'term-query' ) }
+			value={ parent || null }
+			onFilterValueChange={ setSearchInput }
+			onChange={ handleChange }
+			options={ terms?.map( ( { id, name } ) => ( {
+				value: id,
+				label: name,
+			} ) ) }
+		/>
+	);
+};
+
+export default ParentControl;

--- a/src/blocks/term-query/edit/query-content.js
+++ b/src/blocks/term-query/edit/query-content.js
@@ -40,6 +40,7 @@ export default function QueryContent( props ) {
 	const {
 		'term-query/queryId': queryIdContext,
 		'term-query/taxonomy': taxonomyContext,
+		'term-query/termId': termIdContext,
 	} = context;
 	const { __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
@@ -62,6 +63,10 @@ export default function QueryContent( props ) {
 	// Maybe inherit taxonomy from global query if not set in the block.
 	const taxonomyInherited = inherit && ! taxonomyAttribute && (!!queryIdContext && !!taxonomyContext);
 	const taxonomy = taxonomyInherited ? taxonomyContext : taxonomyAttribute;
+
+	// Maybe inherit parent from parent query if not set in the block.
+	const parentInherited = inherit && !!termIdContext;
+	const parent = parentInherited ? termIdContext : query.parent;
 
 	/**
 	 * The term-query/taxonomy context is not declared in the block.json file's
@@ -133,6 +138,7 @@ export default function QueryContent( props ) {
 				attributes={
 					{
 						...attributes,
+						query: { ...query, parent }, // Maybe override parent with inherited value.
 						taxonomy, // Maybe override taxonomy with inherited value.
 					}
 				}

--- a/src/blocks/term-template/edit.js
+++ b/src/blocks/term-template/edit.js
@@ -22,6 +22,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { list, grid } from '@wordpress/icons';
 
 import { getQueryContextFromTemplate } from './utils';
+import withTermQueryProvider from '../../queries/withTermQueryProvider';
 
 const TEMPLATE = [
 	[ 'core/image', {
@@ -130,7 +131,7 @@ function TermTemplateBlockPreview( {
 
 const MemoizedTermTemplateBlockPreview = memo( TermTemplateBlockPreview );
 
-export default function TermTemplateEdit( {
+function TermTemplateEdit( {
 	setAttributes,
 	clientId,
 	context: {
@@ -373,3 +374,5 @@ export default function TermTemplateEdit( {
 		</>
 	);
 }
+
+export default withTermQueryProvider( TermTemplateEdit );

--- a/src/queries/terms.js
+++ b/src/queries/terms.js
@@ -1,0 +1,67 @@
+/**
+ * Term queries.
+ */
+
+import { useQuery, useInfiniteQuery } from '@tanstack/react-query';
+
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+
+export const termQueryKeys = {
+	all: [ 'terms' ],
+	taxonomy: ( taxonomy, args = {} ) => [ ...termQueryKeys.all, { taxonomy, ...args } ],
+	term: ( taxonomy, termId ) => [ ...termQueryKeys.taxonomy( taxonomy, { termId } ) ],
+	search: ( taxonomy, search ) => [ ...termQueryKeys.taxonomy( taxonomy, { search } ) ],
+};
+
+/**
+ * Get a term by ID.
+ */
+export const useTerm = ( taxonomy, termId ) => {
+	const { getEntityRecord } = useSelect( ( select ) => select( coreStore ), [] );
+	return useQuery({
+		queryKey: termQueryKeys.term( taxonomy, termId ),
+		queryFn: async () => {
+			return await getEntityRecord( 'taxonomy', taxonomy, termId ) ?? null;
+		},
+	});
+};
+
+/**
+ * Get the terms for a taxonomy.
+ */
+export const useTerms = ({
+	taxonomy,
+	per_page = 100,
+	parent,
+	search,
+}) => {
+	const {
+		getEntityRecords,
+		getEntityRecordsTotalPages,
+	} = useSelect( ( select ) => select( coreStore ), [] );
+	return useInfiniteQuery({
+		queryKey: search ? termQueryKeys.search( taxonomy, search ) : termQueryKeys.taxonomy( taxonomy ),
+		queryFn: async ({ pageParam = 1 }) => {
+			return await getEntityRecords( 'taxonomy', taxonomy, {
+				context: 'view',
+				per_page,
+				page: pageParam,
+				parent,
+				search,
+			} ) ?? [];
+		},
+		getNextPageParam: ( lastPage, pages, lastPageParam = 1 ) => {
+			const totalPages = getEntityRecordsTotalPages( 'taxonomy', taxonomy, {
+				context: 'view',
+				per_page,
+				parent,
+				search,
+			} ) ?? null;
+			if ( totalPages === null ) {
+				return undefined;
+			}
+			return lastPageParam < totalPages ? lastPageParam + 1 : undefined;
+		},
+	});
+};

--- a/src/queries/withTermQueryProvider.js
+++ b/src/queries/withTermQueryProvider.js
@@ -1,0 +1,19 @@
+/**
+ * queries/withTermQueryProvider.js
+ *
+ * Higher-order component that provides the QueryClient for queries.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const queryClient = new QueryClient();
+
+export const withTermQueryProvider = ( Component ) => {
+	return ( props ) => (
+		<QueryClientProvider client={ queryClient }>
+			<Component { ...props } />
+		</QueryClientProvider>
+	);
+};
+
+export default withTermQueryProvider;


### PR DESCRIPTION
Closes #12 

Adds inspector control for selecting a parent term.

Also includes infrastructure for better structured & cached requests, particularly for paginated content, with `tanstack/react-query`.