### PR TITLE
Feature/query filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,9 @@ Where possible, this plugin has been designed to follow the same extensibility p
 
 The process for registering block variations is very similar to the core Query block,[described here](https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/extending-the-query-loop-block/#extending-the-block-with-variations). The primary differences are that the block to register the variations on is `cr0ybot/term-query`, all attributes will be used except for the `taxonomy`,`parent`, and `inherit` query properties when used via `scope: [ 'block' ]`, and when creating block patterns to associate with a custom variation you should add the name of your variation prefixed with the Term Query Loop block name (e.g. `cr0ybot/term-query/$variation_name`) to the pattern's `blockTypes` property.
 
-### Extending the term query
-
 ### Disabling controls
 
-The process for disabling irrelevant or unsupported controls is similar to the core Query Loop block, [described here](https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/extending-the-query-loop-block/#extending-the-query). The following controls are available for this block:
+The process for disabling irrelevant or unsupported controls is similar to the core Query Loop block, using the variation's `allowedControls` property as [described here](https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/extending-the-query-loop-block/#extending-the-query). The following controls are available for this block:
 
 - `inherit` - Shows the toggle switch for allowing the query to be inherited directly from the template. Hidden automatically if the block is nested.
 - `taxonomy` - Shows a dropdown of available taxonomies.
@@ -80,6 +78,10 @@ The process for disabling irrelevant or unsupported controls is similar to the c
 - `hideEmpty` - Shows a toggle switch for hiding empty terms.
 - `perPage` - Shows a number control for setting the number of terms per page.
 - `stickyTerms` - Shows a search field for adding specific terms to the top of the list.
+
+### Allowlisting taxonomies
+
+Unique to this block, the `allowedTaxonomies` property can be used to limit the taxonomies that can be selected in the block's taxonomy control. This is done by adding the taxonomy slugs to the array. If the property is not set, all taxonomies will be available. Setting the property to an empty array is not advised, as it will prevent any taxonomies from being selected.
 
 ### Adding additional controls
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Controls may be added the same way as the core Query Loop block, [described here
 
 ### Altering the query on the front end
 
-A filter is available to alter the query arguments before they are passed to the `WP_Term_Query` contructor. You can add the filter within a `pre_render_block` filter as [described here](https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/extending-the-query-loop-block/#making-your-custom-query-work-on-the-front-end-side), but you should just be able to check the parsed block's namespace attribute to determine if the args should be filtered as [described in the Filters section below](#filter-term_query_loop_block_query_vars).
+The [term_query_loop_block_query_vars](#filter-term_query_loop_block_query_vars) filter is available to alter the query arguments before they are passed to the `WP_Term_Query` contructor. You can add the filter within a `pre_render_block` filter that checks for the Term Query Loop block's `namespace` attributes as [described here](https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/extending-the-query-loop-block/#making-your-custom-query-work-on-the-front-end-side) to determine whether the filter should be added, as the query vars filter happens within the nested Term Template block (which does not have a namespace attribute).
 
 ### Altering the preview query in the editor
 
@@ -114,15 +114,23 @@ apply_filters( 'term_query_loop_block_query_vars', array $query_vars, WP_Block $
 #### Example
 
 ```php
+add_filter( 'pre_render_block', 'my_apply_term_query_loop_block_filters', 10, 2 );
+
+function my_apply_term_query_loop_block_filters( $pre_render, $parsed_block ) {
+	if ( 'my-plugin/my-term-query' !== $parsed_block['attrs']['namespace'] ) {
+		return $pre_render;
+	}
+
+	add_filter( 'term_query_loop_block_query_vars', 'my_term_query_loop_block_query_vars', 10, 3 );
+
+	return $pre_render;
+}
+
 add_filter( 'term_query_loop_block_query_vars', 'my_term_query_loop_block_query_vars', 10, 3 );
 
 function my_term_query_loop_block_query_vars( $query_vars, $block, $page ) {
-	// Check if we're filtering our custom block variation.
-	if ( 'my-plugin/my-term-query' !== $block->parsed_block['attrs']['namespace'] ) {
-		return $query_vars;
-	}
-
 	// Alter the $query_vars here.
+	$query_vars['orderby'] = 'name';
 
 	return $query_vars;
 }

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Inside the Term Template block, you can add [certain blocks](#block-variations) 
 | --- | --- | --- |
 | `key` | `id`, `slug`, `name`, `description`, `count`, `link`, `parent`, `slug`, `taxonomy` | The key of the term data to display. These generally correspond to the properties returned by the taxonomy REST API endpoint. |
 
-## Term Meta: `term-query/term-meta`
+### Term Meta: `term-query/term-meta`
 
 | Argument | Possible Values | Description |
 | --- | --- | --- |
@@ -56,3 +56,72 @@ The following transformations are available in the plugin:
 - **attachment_id_to_image_alt**: Transforms an attachment ID into the alt text of the attachment.
 
 To create a custom transform, you can use the `term_query_term_meta_transform_{$transform_key}` filter in PHP for the front end and the `termQuery.termMetaTransform.{$transformKey}` filter in JavaScript for the editor. See [includes/transforms.php](/includes/transforms.php) and [src/editor/transforms.js](/src/editor/transforms.js) to reference how the built-in transforms are implemented.
+
+## Extending the Term Query Loop Block
+
+Though the Term Query Loop Block is quite versatile on its own, you can extend it further to present bespoke versions of the block with their own presets and additional or removed settings.
+
+Where possible, this plugin has been designed to follow the same extensibility patterns as the core Query Loop block, [described here](https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/extending-the-query-loop-block/). There are some subtle differences that are detailed below.
+
+### Extending with block variations
+
+The process for registering block variations is very similar to the core Query block,[described here](https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/extending-the-query-loop-block/#extending-the-block-with-variations). The primary differences are that the block to register the variations on is `cr0ybot/term-query`, all attributes will be used except for the `taxonomy`,`parent`, and `inherit` query properties when used via `scope: [ 'block' ]`, and when creating block patterns to associate with a custom variation you should add the name of your variation prefixed with the Term Query Loop block name (e.g. `cr0ybot/term-query/$variation_name`) to the pattern's `blockTypes` property.
+
+### Extending the term query
+
+### Disabling controls
+
+The process for disabling irrelevant or unsupported controls is similar to the core Query Loop block, [described here](https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/extending-the-query-loop-block/#extending-the-query). The following controls are available for this block:
+
+- `inherit` - Shows the toggle switch for allowing the query to be inherited directly from the template. Hidden automatically if the block is nested.
+- `taxonomy` - Shows a dropdown of available taxonomies.
+- `parent` - Shows a dropdown of available parent terms. Hidden automatically if the block is nested.
+- `order` - Shows a dropdown of available order options. Hidden automatically if the block is nested.
+- `hideEmpty` - Shows a toggle switch for hiding empty terms.
+- `perPage` - Shows a number control for setting the number of terms per page.
+- `stickyTerms` - Shows a search field for adding specific terms to the top of the list.
+
+### Adding additional controls
+
+Controls may be added the same way as the core Query Loop block, [described here](https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/extending-the-query-loop-block/#adding-additional-controls).
+
+### Altering the query on the front end
+
+A filter is available to alter the query arguments before they are passed to the `WP_Term_Query` contructor. You can add the filter within a `pre_render_block` filter as [described here](https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/extending-the-query-loop-block/#making-your-custom-query-work-on-the-front-end-side), but you should just be able to check the parsed block's namespace attribute to determine if the args should be filtered as [described in the Filters section below](#filter-term_query_loop_block_query_vars).
+
+### Altering the preview query in the editor
+
+Filtering the query that happens in the editor must be done by filtering the REST response as [described here](https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/extending-the-query-loop-block/#making-your-custom-query-work-on-the-editor-side), except that you must use the `rest_{$this->taxonomy}_query` filter instead of the `rest_{$this->postType}_query` filter.
+
+## Filters
+
+### Filter `term_query_loop_block_query_vars`
+
+Filters the `WP_Term_Query` arguments for the block rendered on the front end. This can be compared to the `query_loop_block_query_vars` filter in the Query Loop block.
+
+```php
+apply_filters( 'term_query_loop_block_query_vars', array $query_vars, WP_Block $block, int $page );
+```
+
+#### Parameters
+
+- `$query_vars` (array): Array containing arguments for `WP_Term_Query` as parsed by the block context.
+- `$block` (WP_Block): The block instance.
+- `$page` (int): The current query's page.
+
+#### Example
+
+```php
+add_filter( 'term_query_loop_block_query_vars', 'my_term_query_loop_block_query_vars', 10, 3 );
+
+function my_term_query_loop_block_query_vars( $query_vars, $block, $page ) {
+	// Check if we're filtering our custom block variation.
+	if ( 'my-plugin/my-term-query' !== $block->parsed_block['attrs']['namespace'] ) {
+		return $query_vars;
+	}
+
+	// Alter the $query_vars here.
+
+	return $query_vars;
+}
+```

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,10 @@ addFilter( 'termQuery.termMetaTransform.prepend_octothorpe', 'me/my-plugin/prepe
 } );
 ```
 
+= How else can I extend the block? =
+
+The Term Query Loop Block has been designed to work very similarly to the core Query Loop block, and the same methods of extending that block also apply here. You can add custom block variations, register patterns, add and remove custom controls, and use filters to adjust the WP_Term_Query arguments. For more details, see the readme at https://github.com/cr0ybot/term-query/blob/main/README.md#extending-the-term-query-loop-block
+
 = What does the ‡ symbol mean? =
 
 The "double dagger" (‡) is a typographical mark generally used to indicate a footnote after both an asterisk (*) and a regular dagger (†) have been used.

--- a/src/blocks/term-query/edit/inspector-controls/index.js
+++ b/src/blocks/term-query/edit/inspector-controls/index.js
@@ -66,6 +66,7 @@ export default function QueryInspectorControls( props ) {
 		isControlAllowed( allowedControls, 'stickyTerms' );
 	const showSettingsPanel =
 		isNested || // If nested, show to display inherited settings.
+		showTaxControl ||
 		showInheritControl ||
 		showColumnsControl ||
 		showOrderControl ||

--- a/src/blocks/term-query/edit/inspector-controls/index.js
+++ b/src/blocks/term-query/edit/inspector-controls/index.js
@@ -75,7 +75,7 @@ export default function QueryInspectorControls( props ) {
 		isControlAllowed( allowedControls, 'hideEmpty' );
 
 	const showPerPageControl = isControlAllowed( allowedControls, 'perPage' );
-	const showPagesControl = isControlAllowed( allowedControls, 'pages' );
+	const showPagesControl = false; // isControlAllowed( allowedControls, 'pages' ); // Not yet supported.
 
 	const showDisplayPanel =
 		showPerPageControl || showPagesControl;

--- a/src/blocks/term-query/edit/inspector-controls/index.js
+++ b/src/blocks/term-query/edit/inspector-controls/index.js
@@ -42,7 +42,7 @@ export default function QueryInspectorControls( props ) {
 		'term-query/termId': termId,
 	} = context;
 	const allowedControls = useAllowedControls( attributes );
-	const taxonomies = useTaxonomies();
+	const taxonomies = useTaxonomies( attributes );
 
 	const updateTaxonomy = ( value ) => {
 		setQuery( { taxonomy: value } );
@@ -115,6 +115,7 @@ export default function QueryInspectorControls( props ) {
 						>
 							{ showTaxControl && (
 								<TaxonomyControl
+									taxonomies={ taxonomies }
 									onChange={ updateTaxonomy }
 									taxonomy={ taxonomy }
 									inherited={ inherit }

--- a/src/blocks/term-query/edit/inspector-controls/taxonomy-control.js
+++ b/src/blocks/term-query/edit/inspector-controls/taxonomy-control.js
@@ -3,11 +3,23 @@ import {
 	TextControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useEffect } from '@wordpress/element';
 
-import { useTaxonomies } from '../../utils';
+export default function TaxonomyControl( { taxonomies, onChange, taxonomy, inherited } ) {
+	/**
+	 * If the selected taxonomy is not in the list of taxonomies, clear the
+	 * selected taxonomy. This might happen if the block variation is changed.
+	 */
+	useEffect(() => {
+		if ( ! taxonomies ) {
+			return;
+		}
 
-export default function TaxonomyControl( { onChange, taxonomy, inherited } ) {
-	const taxonomies = useTaxonomies();
+		if ( ! taxonomies.some( ( { slug } ) => slug === taxonomy ) ) {
+			onChange( undefined );
+		}
+	}, [ taxonomies, taxonomy ]);
+
 	if ( ! taxonomies || taxonomies.length === 0 ) {
 		return null;
 	}

--- a/src/blocks/term-query/edit/query-placeholder.js
+++ b/src/blocks/term-query/edit/query-placeholder.js
@@ -26,7 +26,7 @@ function TaxonomyPicker({ attributes, setAttributes }) {
 	const { query } = attributes;
 	const { taxonomy } = query;
 	const [ selectedTaxonomy, setSelectedTaxonomy ] = useState( taxonomy );
-	const taxonomies = useTaxonomies();
+	const taxonomies = useTaxonomies( attributes );
 
 	const onSubmitTaxonomy = ( event ) => {
 		event.preventDefault();

--- a/src/blocks/term-query/utils.js
+++ b/src/blocks/term-query/utils.js
@@ -87,11 +87,12 @@ export const mapToIHasNameAndId = ( entities, path ) => {
 };
 
 /**
- * Hook that returns all available taxonomies.
+ * Hook that returns all taxonomies available to the block.
  *
  * @return {Object[]} An array of taxonomies.
  */
-export const useTaxonomies = ( ) => {
+export const useTaxonomies = ( attributes ) => {
+	const allowedTaxonomies = useAllowedTaxonomies( attributes );
 	const taxonomies = useSelect(
 		( select ) => {
 			const { getTaxonomies } = select( coreStore );
@@ -102,7 +103,9 @@ export const useTaxonomies = ( ) => {
 		},
 		[]
 	);
-	return taxonomies;
+	return taxonomies?.filter( ( { slug } ) =>
+		isTaxonomyAllowed( allowedTaxonomies, slug )
+	);
 };
 
 /**
@@ -145,6 +148,30 @@ export function isControlAllowed( allowedControls, key ) {
 		return true;
 	}
 	return allowedControls.includes( key );
+}
+
+/**
+ * Hook that returns taxonomies allowed by the active block variation.
+ *
+ * @param {Object} attributes Block attributes.
+ * @return {string[]} An array of allowed taxonomies.
+ */
+export function useAllowedTaxonomies( attributes ) {
+	return useSelect(
+		( select ) =>
+			select( blocksStore ).getActiveBlockVariation(
+				'cr0ybot/term-query',
+				attributes
+			)?.allowedTaxonomies,
+		[ attributes ]
+	);
+}
+export function isTaxonomyAllowed( allowedTaxonomies, taxonomy ) {
+	// Every taxonomy is allowed if the list is not defined.
+	if ( ! allowedTaxonomies ) {
+		return true;
+	}
+	return allowedTaxonomies.includes( taxonomy );
 }
 
 /**

--- a/src/blocks/term-query/utils.js
+++ b/src/blocks/term-query/utils.js
@@ -132,7 +132,7 @@ export function useAllowedControls( attributes ) {
 	return useSelect(
 		( select ) =>
 			select( blocksStore ).getActiveBlockVariation(
-				'term-query/terms',
+				'cr0ybot/term-query',
 				attributes
 			)?.allowedControls,
 

--- a/src/blocks/term-template/edit.js
+++ b/src/blocks/term-template/edit.js
@@ -126,11 +126,11 @@ function TermTemplateEdit( {
 			inherit,
 			pages,
 			parent = 0,
-			// We gather extra query args to pass to the REST API call.
-			// This way extenders of Query Loop can add their own query args,
+			// Gather extra query args to pass to the REST API call.
+			// This way extenders of Term Query Loop can add their own query args,
 			// and have accurate previews in the editor.
 			// Noting though that these args should either be supported by the
-			// REST API or be handled by custom REST filters like `rest_{$this->post_type}_query`.
+			// REST API or be handled by custom REST filters like `rest_{$this->taxonomy}_query`.
 			...restQueryArgs
 		} = {},
 		'term-query/termId': termId,

--- a/src/blocks/term-template/render.php
+++ b/src/blocks/term-template/render.php
@@ -43,7 +43,30 @@ if ( ! function_exists( 'ctq_build_query_vars_from_term_query_block' ) ) {
 		// Merge with additional args.
 		$query_args = array_merge( $query_args, $args );
 
-		return $query_args;
+		/**
+		 * Filters the arguments which will be passet to `WP_Term_Query` for the
+		 * Term Query Loop Block.
+		 *
+		 * Anything that is returned from this filter should be compatible with
+		 * the `WP_Term_Query` API to form the query context which will be
+		 * passed down to the block's children. This can help, for example, to
+		 * include additional settings or meta queries not directly supported by
+		 * the block's settings, and extend its capabilities.
+		 *
+		 * Please note that this will only influence the query that will be
+		 * rendered on the front end. The editor preview is not affected by this
+		 * filter. Also, it is worth noting that the editor preview uses the
+		 * REST API, so, ideally, one should aim to provide attributes which are
+		 * also compatible with the REST API in order to be able to implement
+		 * identical queries on both sides.
+		 *
+		 * @since 0.7.0
+		 *
+		 * @param array   $query_args Array containing arguments for `WP_Term_Query` as parsed by the block context.
+		 * @param WP_Block $block The block instance.
+		 * @param int      $page The current query's page.
+		 */
+		return apply_filters( 'term_query_loop_block_query_vars', $query_args, $block, $page );
 	}
 }
 

--- a/src/blocks/term-template/render.php
+++ b/src/blocks/term-template/render.php
@@ -20,7 +20,6 @@ if ( ! function_exists( 'ctq_build_query_vars_from_term_query_block' ) ) {
 	 */
 	function ctq_build_query_vars_from_term_query_block( $block, $page, $args = array() ) {
 		if ( ! isset( $block->context['term-query/query'] ) ) {
-			error_log( 'No query found in context.' );
 			return null;
 		}
 
@@ -76,7 +75,6 @@ $page = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
 
 // If termId is provided in context, this is a nested term query block and we should use that as the parent.
 if ( isset( $block->context['term-query/termId'] ) ) {
-	error_log( 'Using termId from context:', $block->context['term-query/termId'] );
 	// If termId is already provided in context, use that as parent.
 	$term_id    = $block->context['term-query/termId'];
 	$query_args = ctq_build_query_vars_from_term_query_block(
@@ -95,12 +93,10 @@ if ( isset( $block->context['term-query/termId'] ) ) {
 	// Use global query if needed.
 	$use_global_query = ( isset( $block->context['term-query/query']['inherit'] ) && $block->context['term-query/query']['inherit'] );
 	if ( $use_global_query ) {
-		error_log( 'Inheriting query from context.' );
 
 		global $wp_query;
 
 		$context_query = $block->context['term-query/query'];
-		error_log( 'No termId in context, using query from context:', print_r( $context_query, true ) );
 
 		if ( ! in_the_loop() && ( is_category() || is_tag() || is_tax() ) ) {
 			/**
@@ -118,14 +114,12 @@ if ( isset( $block->context['term-query/termId'] ) ) {
 					'hide_empty' => $context_query['hideEmpty'],
 				)
 			);
-			error_log( 'Got terms from queried object:', $wp_query->get_queried_object_id() );
 		} elseif ( is_single() || in_the_loop() ) {
 			/**
 			 * If the global query is for a single post or we're in the main loop,
 			 * get the terms from the post.
 			 */
 			$terms = get_the_terms( get_the_ID(), $context_query['taxonomy'] );
-			error_log( 'Got terms from post:', get_the_ID() );
 		} elseif ( isset( $block->context['postId'] ) ) {
 			/**
 			 * Otherwise, get the postID from context.
@@ -133,9 +127,7 @@ if ( isset( $block->context['term-query/termId'] ) ) {
 			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 			$post_id = $block->context['postId'];
 			$terms   = get_the_terms( $post_id, $context_query['taxonomy'] );
-			error_log( 'Got terms from postId context:', $post_id );
 		} else {
-			error_log( 'No terms found in context.' );
 			$terms = array();
 		}
 	} else {


### PR DESCRIPTION
Closes #26 

Adds the `term_query_loop_block_query_vars` filter and documentation about all the various ways the block can be extended. This also includes: the new `allowedTaxonomies` setting.